### PR TITLE
Various fixes and updates

### DIFF
--- a/check.patch
+++ b/check.patch
@@ -1,56 +1,57 @@
-From e92413c320e5e1e99205b23b10462dbfb3592667 Mon Sep 17 00:00:00 2001
-From: Matt Jolly <kangie@gentoo.org>
-Date: Wed, 27 Aug 2025 18:18:07 +1000
-Subject: [PATCH] Note: The result of applying this patch is not used.
-
 This patch serves only to check whether the relevant portion of the
 export_lite_tarball() function in the publish_tarball.py script has
 changed, indicating that we need to update the prune_lite_excluded_dirs()
 function in package_chromium.sh.
 
-Signed-off-by: Matt Jolly <kangie@gentoo.org>
+
 --- a/build/recipes/recipes/publish_tarball.py
 +++ b/build/recipes/recipes/publish_tarball.py
-@@ -320,68 +320,9 @@ def copytree_checkout(api, source_dir):
- 
+@@ -326,77 +326,10 @@ def copytree_checkout(api, source_dir):
  def export_lite_tarball(api, source_dir, version):
    # Make destructive file operations on the copy of the checkout.
--  with copytree_checkout(api, source_dir) as dest_dir:
--    directories = [
+   with copytree_checkout(api, source_dir) as dest_dir:
+-    prune_directories = [
 -        'android_webview',
--        'build/linux/debian_bullseye_amd64-sysroot',
--        'build/linux/debian_bullseye_i386-sysroot',
--        'buildtools/reclient',
 -        'chrome/android',
 -        'chromecast',
 -        'ios',
 -        'third_party/android_platform',
+-        'third_party/closure_compiler',
+-        'third_party/instrumented_libs',
+-        'third_party/libphonenumber/dist/resources/metadata',
+-    ]
+-
+-    if version_ships_nacl(version):
+-      prune_directories.extend([
+-          'native_client',
+-          'native_client_sdk',
+-      ])
+ 
+-    # These directories will be deleted completely rather than pruned.
+-    # Only add items that do not ship to end users! We need to retain
+-    # licensing info for anything that does.
+-    purge_directories = [
+-        'build/linux/debian_bullseye_amd64-sysroot',
+-        'build/linux/debian_bullseye_i386-sysroot',
+-        'buildtools/reclient',
 -        'third_party/angle/third_party/VK-GL-CTS',
 -        'third_party/apache-linux',
 -        'third_party/catapult/third_party/vinn/third_party/v8',
--        'third_party/closure_compiler',
--        'third_party/instrumented_libs',
+-        'third_party/dawn/third_party/khronos/OpenGL-Registry/specs',
+-        'third_party/dawn/tools/golang',
+-        'third_party/jetstream',
 -        'third_party/llvm',
 -        'third_party/llvm-build',
 -        'third_party/llvm-build-tools',
 -        'third_party/node/linux',
 -        'third_party/rust-src',
 -        'third_party/rust-toolchain',
+-        'third_party/speedometer',
 -        'third_party/webgl',
+-        'tools/skia_goldctl',
 -    ]
--    for directory in [
--        'third_party/blink/manual_tests', 'third_party/blink/perf_tests'
--    ]:
--      if api.path.exists(api.path.join(dest_dir, directory)):
--        directories.append(directory)  # pragma: no cover
 -
--    if version_ships_nacl(version):
--      directories.extend([
--          'native_client',
--          'native_client_sdk',
--      ])
--
--    for directory in directories:
+-    for directory in prune_directories:
 -      try:
 -        api.step('prune %s' % directory, [
 -            'find', api.path.join(dest_dir, directory),
@@ -73,15 +74,16 @@ Signed-off-by: Matt Jolly <kangie@gentoo.org>
 -        # or deleted in different versions of the codebase.
 -        pass
 -
--    # Empty directories take up space in the tarball.
--    api.step('prune empty directories',
--             ['find', dest_dir, '-depth', '-type', 'd', '-empty', '-delete'])
+-    for directory in purge_directories:
+-      api.file.rmtree('purge %s' % directory,
+-                      api.path.join(dest_dir, directory))
 -
-+  #
-+  # Relevant code deleted
-+  #
+-    # Empty directories take up space in the tarball.
+-    api.step('delete empty directories',
+-             ['find', dest_dir, '-depth', '-type', 'd', '-empty', '-delete'])
++    #
++    # Relevant code deleted
++    #
+ 
      export_tarball(
          api,
-         # Verbose output helps avoid a buildbot timeout when no output
--- 
-2.50.1

--- a/gitconfig
+++ b/gitconfig
@@ -1,0 +1,15 @@
+# Reduce noise
+[advice]
+	detachedHead = false
+
+# The following settings are used in Google's tarball-building process,
+# visible under third_party/rust-src/.git/
+
+[init]
+	defaultBranch = master
+
+[user]
+	name = chromium-tarball-builder
+	email = chromium-tarball-builder@chops-service-accounts.iam.gserviceaccount.com
+
+# end gitconfig

--- a/tweak-src.patch
+++ b/tweak-src.patch
@@ -11,11 +11,3 @@ This patch is applied by the package_chromium.sh script.
  
    if RunCommand(clone_cmd, fail_hard=False):
      os.chdir(dir)
-@@ -546,6 +546,7 @@
- 
- 
- def DownloadDebianSysroot(platform_name, skip_download=False):
-+  skip_download = True
-   # Download sysroots. This uses basically Chromium's sysroots, but with
-   # minor changes:
-   # - glibc version bumped to 2.18 to make __cxa_thread_atexit_impl


### PR DESCRIPTION
Our LLVM and Rust downloads have been failing due to unknown changes in Google's infrastructure, and I've pushed an [update](https://crrev.com/c/7167308) to the upstream tarball scripts that needs reflecting here.

* Update `check.patch` to reflect the updated `publish_tarball.py`

* Add a Git config file, as the LLVM cloning process fails without a defined Git user; this also includes other settings that reduce extraneous messages and better match Google's process

* Allow the `package_chromium.sh` to run from any directory (i.e. use `/path/to/package_chromium.sh` instead of just `./package_chromium.sh`)

* Make generation of the full and test-data tarballs optional, so that we can avoid the LLVM/Rust steps in the common case

* Update the shallow-clone date for LLVM

* Don't use a shallow clone for the Rust repo, as for some reason the repo server doesn't support it (even though other repos on the same server handle it just fine)

* Implement new prune/purge-list duopoly for the lite tarball

* Allow specifying the export_tarball script to use via an environment variable

* Set a California time zone, as this appears to affect the Git content under `third_party/rust-src/.git/`

* Re-enable the downloading of sysroots, as this is now used (only) when making the full tarball