### PR TITLE
Add sync of native Rollup

### DIFF
--- a/package_chromium.sh
+++ b/package_chromium.sh
@@ -87,6 +87,9 @@ run_hooks() {
 		--revision src/gpu/webgpu/DAWN_VERSION \
 		--header src/gpu/webgpu/dawn_commit_hash.h
 
+	(cd src/third_party/devtools-frontend/src &&
+		python3 scripts/deps/sync_rollup_libs.py)
+
 	touch src/chrome/test/data/webui/i18n_process_css_test.html
 
 	src/tools/update_pgo_profiles.py \


### PR DESCRIPTION
Match this upstream change: https://crrev.com/c/7532444

This gets the tarball build working again after the switch to a native Rollup implementation (see https://crbug.com/461602362)

----

Should fix #32.