### PR TITLE
Revert "Add sync of native Rollup"

### DIFF
--- a/package_chromium.sh
+++ b/package_chromium.sh
@@ -87,9 +87,6 @@ run_hooks() {
 		--revision src/gpu/webgpu/DAWN_VERSION \
 		--header src/gpu/webgpu/dawn_commit_hash.h
 
-	(cd src/third_party/devtools-frontend/src &&
-		python3 scripts/deps/sync_rollup_libs.py)
-
 	touch src/chrome/test/data/webui/i18n_process_css_test.html
 
 	src/tools/update_pgo_profiles.py \


### PR DESCRIPTION
Rollup got replaced with esbuild, including a backport to M144 stable, which makes tarball generation fail with ENOENT of this script. https://source.chromium.org/chromium/_/chromium/devtools/devtools-frontend/+/f130475580017f9f87502343dbcfc0c76dccefe8

This reverts commit db08f2bd2a86ee95e45d9e60c27c76b7b2b612e0.