### PR TITLE
Fix the 144.* series, which didn't get sync_rollup_libs.py

### DIFF
--- a/package_chromium.sh
+++ b/package_chromium.sh
@@ -88,7 +88,7 @@ run_hooks() {
 		--header src/gpu/webgpu/dawn_commit_hash.h
 
 	(cd src/third_party/devtools-frontend/src &&
-		python3 scripts/deps/sync_rollup_libs.py)
+		python3 scripts/deps/sync_rollup_libs.py) || true
 
 	touch src/chrome/test/data/webui/i18n_process_css_test.html
 


### PR DESCRIPTION
I missed that the native-Rollup business didn't make it to 144.*  >_<

The [upstream fix](https://crrev.com/c/7542157) is pending; here is ours. Doing it quick and dirty because [another CL of mine](https://crrev.com/c/7538780) will do away with this rigmarole altogether.