### PR TITLE
Updates to match Google's process, support ChromeOS LTS revs

### DIFF
--- a/package_chromium.sh
+++ b/package_chromium.sh
@@ -56,41 +56,18 @@ configure_gclient() {
 
 # This function runs a series of hooks to update various build-related files.
 # It performs the following actions:
-# 1. Updates the LASTCHANGE file with the latest change information.
-# 2. Updates the GPU lists version header with the latest revision ID.
-# 3. Updates the Skia commit hash header with the latest commit hash from the Skia repository.
-# 4. Updates the DAWN version with the latest revision from the Dawn repository.
-# 5. Touches the i18n_process_css_test.html file to ensure that it exists. Tests fail if this file does not exist.
-# 6. Updates the PGO profiles for the Linux target using the specified Google Storage URL base.
-# 7. Updates the V8 PGO profiles.
+# * Updates the PGO profiles for the Linux target using the specified Google Storage URL base.
+# * Updates the V8 PGO profiles.
+# * Copies the clang-format script to src/buildtools/linux64/.
+#
+# If generating all tarballs:
+# * Downloads LLVM components.
+# * Downloads Rust components.
 #
 # These largely match what Google does in their process:
 # https://chromium.googlesource.com/chromium/tools/build/+/refs/heads/main/recipes/recipes/publish_tarball.py
 run_hooks() {
-	clog "Running post-checkout hooks"
-
-	src/build/util/lastchange.py -o src/build/util/LASTCHANGE
-
-	src/build/util/lastchange.py \
-		-m GPU_LISTS_VERSION \
-		--revision-id-only \
-		--header src/gpu/config/gpu_lists_version.h
-
-	src/build/util/lastchange.py \
-		-m SKIA_COMMIT_HASH \
-		-s src/third_party/skia \
-		--header src/skia/ext/skia_commit_hash.h
-
-	src/build/util/lastchange.py \
-		-m DAWN_COMMIT_HASH \
-		-s src/third_party/dawn \
-		--revision src/gpu/webgpu/DAWN_VERSION \
-		--header src/gpu/webgpu/dawn_commit_hash.h
-
-	(cd src/third_party/devtools-frontend/src &&
-		python3 scripts/deps/sync_rollup_libs.py) || true
-
-	touch src/chrome/test/data/webui/i18n_process_css_test.html
+	clog "Running additional post-checkout hooks"
 
 	src/tools/update_pgo_profiles.py \
 		--target=linux \
@@ -105,9 +82,12 @@ run_hooks() {
 		download ||
 		die "Failed to download V8 PGO profiles"
 
+	cp -f build/recipes/recipe_modules/chromium/resources/clang-format \
+		src/buildtools/linux64/
+
 	if ${GENERATE_ALL}; then
-		# This keeps down the size of the LLVM clone operation.
-		export EXTRA_GIT_CLONE_ARGS="-q --shallow-since=2025-09-01"
+		# This keeps down the size of the LLVM/Rust clone operations.
+		export EXTRA_GIT_CLONE_ARGS="-q --shallow-since=2025-05-01"
 
 		if ! src/tools/clang/scripts/build.py \
 			--without-android \
@@ -119,18 +99,12 @@ run_hooks() {
 			rm -rf src/third_party/llvm
 		fi
 
-		# Note: Google's mirror of the Rust Git repo does not appear to
-		# support shallow cloning (it simply returns an empty repo).
-		export EXTRA_GIT_CLONE_ARGS="-q"
-
 		if ! src/tools/rust/build_rust.py --sync-for-gnrt
 		then
 			cwarn "Failed to download Rust components, excluding from tarball"
 			rm -rf src/third_party/rust-src
 		fi
 	fi
-
-	cp -f build/recipes/recipe_modules/chromium/resources/clang-format src/buildtools/linux64/
 }
 
 get_gn_sources() {
@@ -326,9 +300,9 @@ main() {
 
 	configure_gclient "${version}"
 	# We don't need the full history of the Chromium repository to
-	# generate a tarball, and we'll run a limited subset of manual hooks.
+	# generate a tarball.
 	clog "Syncing Chromium sources with no history"
-	gclient sync --nohooks --no-history
+	gclient sync -D --no-history ${EXTRA_GCLIENT_ARGS:-}
 
 	clog "Patching upstream scripts"
 	patch -p1 --no-backup-if-mismatch < "${base}/tweak-src.patch" ||


### PR DESCRIPTION
* Run `gclient` without `--nohooks`, now that Google is doing this. This lets us cut down the `run_hooks()` function significantly, as there is no longer a need to manually curate a set of hooks duplicating those in the Chromium `DEPS` files.

* Shallow-clone the LLVM and Rust repos going back to a somewhat earlier date, to allow generating a tarball for 138.0.7204.304 (the current ChromeOS LTS rev)

* For that matter, we are now actually able to shallow-clone the Rust repo, thanks to https://crbug.com/481090121 getting resolved

* Add a variable `EXTRA_GCLIENT_ARGS` to allow passing additional parameters to the `gclient` invocation

----

@Kangie, I forgot to push out this change after landing the `--nohooks` removal upstream. Really need to write up that job that compares tarball hashes...

@selfisekai, I updated the shallow-clone dates so the script will support generating a full-fat tarball in the current ChromeOS LTS.